### PR TITLE
Disable boringdroid system apps temporarily

### DIFF
--- a/boringdroid.mk
+++ b/boringdroid.mk
@@ -4,13 +4,13 @@ PRODUCT_SYSTEM_DEFAULT_PROPERTIES += \
     persist.sys.pcmode.enabled=true \
     persist.sys.systemuiplugin.enabled=true \
 
-PRODUCT_PACKAGES := \
-    BoringdroidSystemUIApk \
-    BoringdroidSettingsApk \
+# PRODUCT_PACKAGES := \
+#     BoringdroidSystemUIApk \
+#     BoringdroidSettingsApk \
 
 # rro overlay
-PRODUCT_PACKAGES += \
-    BoringdroidSystemUIOverlay
+# PRODUCT_PACKAGES += \
+#     BoringdroidSystemUIOverlay
 
 PRODUCT_COPY_FILES := \
     frameworks/native/data/etc/android.software.freeform_window_management.xml:system/etc/permissions/android.software.freeform_window_management.xml


### PR DESCRIPTION
They will bring compile time's dex2oat verification errors.