### PR TITLE
Enable BoringdroidSettings integration again

### DIFF
--- a/boringdroid.mk
+++ b/boringdroid.mk
@@ -3,9 +3,9 @@ PRODUCT_SYSTEM_DEFAULT_PROPERTIES += \
     ro.recents.grid=true \
     persist.sys.systemuiplugin.enabled=true
 
-# PRODUCT_PACKAGES := \
+ PRODUCT_PACKAGES := \
+     BoringdroidSettingsApk \
 #     BoringdroidSystemUIApk \
-#     BoringdroidSettingsApk \
 
 # rro overlay
 # PRODUCT_PACKAGES += \


### PR DESCRIPTION
I can open it from build-in Settings.